### PR TITLE
Do not upload entire project as artifcat

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,9 +1,7 @@
 name: Create and publish a packages
 on:
-  push:
-    # Sequence of patterns matched against refs/tags
-    tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  release:
+    types: [created]
 jobs:
   run-npm-build:
     runs-on: ubuntu-latest
@@ -16,7 +14,7 @@ jobs:
       - uses: actions/upload-artifact@main
         with:
           name: artifacts
-          path: './'
+          path: /public
 
   run-npm-test:
     runs-on: ubuntu-latest
@@ -34,7 +32,7 @@ jobs:
       - uses: actions/download-artifact@main
         with:
           name: artifacts
-          path: './'
+          path: public
       - name: npm install, and test
         run: |
           npm install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable -->
 ## [Unreleased]
 
+## [v1.0.2] - 2021-02-16
+
+### Changed
+- Publish packages on release created instead of tag
+- Do not upload entire root directory as artifact
+
 ## [v1.0.1]
 
 ### Added


### PR DESCRIPTION
### Changed
- Publish packages on release created instead of tag
- Do not upload entire root directory as artifact
