### PR TITLE
Update `@shgysk8zer0/rollup-import` to v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable -->
 ## [Unreleased]
 
+## [v3.0.4] - 2023-05-13
+
+### Changed
+- Update `@shgysk8zer0/rollup-import` to v1.0.0
+
 ## [v3.0.3] - 2023-05-12
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "netlify-js-app",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "netlify-js-app",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.13.15",
         "@rollup/plugin-terser": "^0.4.1",
-        "@shgysk8zer0/rollup-import": "^0.0.4",
+        "@shgysk8zer0/rollup-import": "^1.0.0",
         "cssnano": "^6.0.0",
         "cssnano-preset-default": "^6.0.0",
         "eslint": "^8.0.1",
@@ -1220,14 +1220,14 @@
       }
     },
     "node_modules/@shgysk8zer0/rollup-import": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@shgysk8zer0/rollup-import/-/rollup-import-0.0.4.tgz",
-      "integrity": "sha512-30AQqm92oB91XxJRaI4cBw4lYFmRH2Tjn3mqEYdvt83HOt2IUqgabcR0gg9vTI65l9w0F0+jPQnusEMk2unNXQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@shgysk8zer0/rollup-import/-/rollup-import-1.0.0.tgz",
+      "integrity": "sha512-CejjHIQ0bEduSSzR7+KFc2OpeDYpjV4LRe/s5DzgSUTmw/OaD5MEgHSEaNvRfYVfUA4Bl/TL83Xc91qFDmaI3w==",
       "dependencies": {
         "yaml": "^2.2.2"
       },
       "engines": {
-        "node": ">=18.13.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "rollup": "*"
@@ -22072,9 +22072,9 @@
       }
     },
     "@shgysk8zer0/rollup-import": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@shgysk8zer0/rollup-import/-/rollup-import-0.0.4.tgz",
-      "integrity": "sha512-30AQqm92oB91XxJRaI4cBw4lYFmRH2Tjn3mqEYdvt83HOt2IUqgabcR0gg9vTI65l9w0F0+jPQnusEMk2unNXQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@shgysk8zer0/rollup-import/-/rollup-import-1.0.0.tgz",
+      "integrity": "sha512-CejjHIQ0bEduSSzR7+KFc2OpeDYpjV4LRe/s5DzgSUTmw/OaD5MEgHSEaNvRfYVfUA4Bl/TL83Xc91qFDmaI3w==",
       "requires": {
         "yaml": "^2.2.2"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netlify-js-app",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "engines": {
     "node": ">=18.13.0"
   },
@@ -54,7 +54,7 @@
   "dependencies": {
     "@babel/core": "^7.13.15",
     "@rollup/plugin-terser": "^0.4.1",
-    "@shgysk8zer0/rollup-import": "^0.0.4",
+    "@shgysk8zer0/rollup-import": "^1.0.0",
     "cssnano": "^6.0.0",
     "cssnano-preset-default": "^6.0.0",
     "eslint": "^8.0.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,5 @@
 /* eslint-env node */
 
-import urlResolve from 'rollup-plugin-url-resolve';
 import terser from '@rollup/plugin-terser';
 import { rollupImport } from '@shgysk8zer0/rollup-import';
 
@@ -13,7 +12,6 @@ export default {
 	},
 	plugins: [
 		rollupImport(['importmap.json']),
-		urlResolve(),
 		terser(),
 	],
 };


### PR DESCRIPTION
`rollup-plugin-url-resolve` is now considered deprecated and will be removed in the future. It is seemingly abandoned, does not use native `fetch()`, and hasn't been updated in about 2 years.
